### PR TITLE
Fixes remill compatibility after SPARC support merge

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -5,8 +5,12 @@
 #include <circuitous/IR/IR.h>
 #include <circuitous/Printers.h>
 #include <circuitous/Transforms.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wconversion"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#pragma clang diagnostic pop
 
 #include <fstream>
 #include <iostream>

--- a/include/circuitous/Util/UseDef.h
+++ b/include/circuitous/Util/UseDef.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wconversion"
 #include <glog/logging.h>
+#pragma clang diagnostic pop
 
 #include <algorithm>
 #include <cassert>

--- a/lib/IR/Hash.cpp
+++ b/lib/IR/Hash.cpp
@@ -5,8 +5,11 @@
 #include <circuitous/IR/Hash.h>
 #include <circuitous/IR/IR.h>
 #include <circuitous/Util/BitManipulation.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Instructions.h>
+#pragma clang diagnostic pop
 
 #include <string>
 #include <unordered_map>

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -3,11 +3,15 @@
  */
 
 #include <circuitous/IR/IR.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wconversion"
 #include <glog/logging.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
+#pragma clang diagnostic pop
 
 #include <sstream>
 #include <unordered_map>

--- a/lib/IR/Serialize.cpp
+++ b/lib/IR/Serialize.cpp
@@ -5,7 +5,12 @@
 #include <circuitous/IR/Hash.h>
 #include <circuitous/IR/IR.h>
 #include <circuitous/Printers.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wconversion"
 #include <glog/logging.h>
+#pragma clang diagnostic pop
+
 
 #include <algorithm>
 #include <cstdint>

--- a/lib/Lifter/CircuitBuilder.cpp
+++ b/lib/Lifter/CircuitBuilder.cpp
@@ -4,10 +4,14 @@
 
 #include "CircuitBuilder.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wconversion"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <llvm/ADT/PostOrderIterator.h>
 #include <llvm/IR/CFG.h>
+#pragma clang diagnostic pop
 
 namespace circuitous {
 namespace {

--- a/lib/Lifter/CircuitBuilder.h
+++ b/lib/Lifter/CircuitBuilder.h
@@ -60,8 +60,8 @@ class CircuitBuilder {
   explicit CircuitBuilder(T initialize_arch)
       : arch(initialize_arch(context)),
         module(remill::LoadArchSemantics(arch)),
-        state_ptr_type(remill::StatePointerType(module.get())),
-        mem_ptr_type(remill::MemoryPointerType(module.get())),
+        state_ptr_type(arch->StatePointerType()),
+        mem_ptr_type(arch->MemoryPointerType()),
         i32_type(llvm::Type::getInt32Ty(context)),
         bool_type(llvm::Type::getInt1Ty(context)),
         true_value(llvm::ConstantInt::get(bool_type, 1)),

--- a/lib/Lifter/Remill.cpp
+++ b/lib/Lifter/Remill.cpp
@@ -3,6 +3,9 @@
  */
 
 #include <circuitous/IR/IR.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wconversion"
 #include <glog/logging.h>
 #include <llvm/ADT/SmallString.h>
 #include <llvm/IR/BasicBlock.h>
@@ -17,6 +20,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/raw_ostream.h>
+#pragma clang diagnostic pop
 #include <remill/Arch/Arch.h>
 #include <remill/Arch/Name.h>
 #include <remill/BC/Compat/Error.h>

--- a/lib/Printers/SMT.cpp
+++ b/lib/Printers/SMT.cpp
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2020 Trail of Bits, Inc.
  */
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
 #include <glog/logging.h>
 #include <llvm/IR/InstrTypes.h>
 #include <z3++.h>
+#pragma clang diagnostic pop
 
 #include <memory>
 #include <unordered_map>

--- a/lib/Transforms/ConvertPopCountToParity.cpp
+++ b/lib/Transforms/ConvertPopCountToParity.cpp
@@ -4,7 +4,10 @@
 
 #include <circuitous/IR/IR.h>
 #include <circuitous/Transforms.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
 #include <llvm/IR/Instruction.h>
+#pragma clang diagnostic pop
 
 namespace circuitous {
 

--- a/lib/Transforms/ExtractCommonTopologies.cpp
+++ b/lib/Transforms/ExtractCommonTopologies.cpp
@@ -5,7 +5,10 @@
 #include <circuitous/IR/IR.h>
 #include <circuitous/Printers.h>
 #include <circuitous/Transforms.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
 #include <llvm/IR/Instruction.h>
+#pragma clang diagnostic pop
 
 #include <sstream>
 #include <unordered_map>

--- a/lib/Transforms/StrengthReducePopulationCount.cpp
+++ b/lib/Transforms/StrengthReducePopulationCount.cpp
@@ -4,7 +4,10 @@
 
 #include <circuitous/IR/IR.h>
 #include <circuitous/Transforms.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
 #include <llvm/IR/Instruction.h>
+#pragma clang diagnostic pop
 
 namespace circuitous {
 


### PR DESCRIPTION
* adds ignore compiler diagnostic pragmas around 3rd party header includes
* replaces deprecated remill API usage