### PR TITLE
ir: Fix a bug where meta-data would not be updated/replaced.

### DIFF
--- a/include/circuitous/IR/Metadata.hpp
+++ b/include/circuitous/IR/Metadata.hpp
@@ -45,7 +45,7 @@ namespace circ {
       if constexpr (!rewrite) {
         check(!has_meta(key));
       }
-      meta.emplace(std::move(key), std::move(val));
+      meta[std::move(key)] = std::move(val);
     }
 
     std::string dump_meta() const {


### PR DESCRIPTION
calling emplace does not update an existing entry.
`=` operator both inserts new and overrides old entries 