### PR TITLE
ir: Fix a bug where removal of duplicated children caused aborts.

### DIFF
--- a/include/circuitous/IR/Storage.hpp
+++ b/include/circuitous/IR/Storage.hpp
@@ -20,8 +20,9 @@ namespace circ
         {
             auto notify_operands = [](auto &&x)
             {
-                for (auto op : x->operands)
-                    op->remove_user(x.get());
+                // assumes remove_use removes the operand from x
+                while (!x->operands.empty())
+                    x->operands[ 0 ]->remove_use( x.get());
             };
             return data.remove_unused(notify_operands);
         }


### PR DESCRIPTION
Currently remove_unused removes all links between possibly used children and the unused parent.

If the parent has 2 edges to the same child, then it will call `child->remove_user(parent)` twice. 
Even though all edges to the parent are removed on the first call already. Breaking the assert of that something is removed in `remove_user`.

This should fix that 
