### PR TITLE
pass: Add pass that removes concat nodes with one operand.

### DIFF
--- a/include/circuitous/Transforms/Passes.hpp
+++ b/include/circuitous/Transforms/Passes.hpp
@@ -70,6 +70,20 @@ namespace circ
     static Pass get() { return std::make_shared< DummyPass >(); }
   };
 
+  struct TrivialConcatRemovalPass : PassBase
+  {
+      CircuitPtr run( CircuitPtr &&circuit ) override
+      {
+          for ( auto c : circuit->attr< Concat >() )
+              if ( c->operands.size() == 1 )
+                  c->replace_all_uses_with( c->operands[ 0 ] );
+
+          return std::move( circuit );
+      }
+
+      static Pass get() { return std::make_shared< TrivialConcatRemovalPass >(); }
+  };
+
   struct PassesBase
   {
     // list of recognized passes
@@ -77,7 +91,8 @@ namespace circ
     {
       { "eqsat",           EqualitySaturationPass::get() },
       { "merge-advices",   MergeAdvicesPass::get() },
-      { "dummy-pass",      DummyPass::get() }
+      { "dummy-pass",      DummyPass::get() },
+      { "trivial-concat-removal", TrivialConcatRemovalPass::get() },
     };
 
     NamedPass &add_pass(const std::string &name) {


### PR DESCRIPTION
A fix for #267. 

Not included by default but right now but this will be used by the `decoder` later on. 
This should also be added to the `simplify` option in #255 after that is merged in.