### PR TITLE
ir: Fix incorrect arity verification error message.

### DIFF
--- a/lib/IR/Verify.cpp
+++ b/lib/IR/Verify.cpp
@@ -247,19 +247,19 @@ namespace circ
         auto print_op = [&](auto root, const auto &prefix)
         {
             ss << prefix;
-            if (auto src = op->get_meta(circir_llvm_meta::llvm_source_dump))
+            if (auto src = root->get_meta(circir_llvm_meta::llvm_source_dump))
                 ss << *src;
             else
                 ss << "( no source meta )";
             ss << "\n";
-            return ss.str();
         };
 
-        std::string out = print_op(op, gprefix);
+        print_op(op, gprefix);
 
         for (auto c : op->operands)
-            out += print_op(c, gprefix + " |- ");
-        return out;
+            print_op(c, gprefix + " |- ");
+
+        return ss.str();
     }
 
 


### PR DESCRIPTION
If an op would fail a `more_than(2...` check by having a single operand, than the output before this PR would be:
```
errors:
 * concat has 1 operands which is invalid.
        [ 53 ]:   %133 = call i64 (...) @__circuitous.concat.64(i64 %2)
        [ 53 ]:   %133 = call i64 (...) @__circuitous.concat.64(i64 %2)
         |- [ 53 ]:   %133 = call i64 (...) @__circuitous.concat.64(i64 %2)
Error entry end.
```

After the PR would be:
```
errors:
 * concat has 1 operands which is invalid.
        [ 68 ]:   %133 = call i64 (...) @__circuitous.concat.64(i64 %2)
         |- [ 67 ]:   %2 = call i64 (i4, ...) @__circuitous.select.4.64(i4 %1, i64 %RAX.in, i64 %RCX.in, i64 %RDX.in, i64 %RBX.in, i64 %RSP.in, i64 %RBP.in, i64 %RSI.in, i64 %RDI.in, i64 %R8.in, i64 %R9.in, i64 %R10.in, i64 %R11.in, i64 %R12.in, i64 %R13.in, i64 %R14.in, i64 %R15.in)
Error entry end.
```
